### PR TITLE
Encoders: Update encoder schema

### DIFF
--- a/src/absenc_interface/src/absenc.cpp
+++ b/src/absenc_interface/src/absenc.cpp
@@ -179,7 +179,7 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
     // Construct the measurement data storage object
     meas->slvnum = slvnum; // Slave number
     meas->status = rawdata[1]; // Status value (usually zero)
-    meas->angval = ((double)(int16_t)rawdata[1]) / 65536.0 * 360.0; // Angular value, maps the uint16_t space to 360 degrees
+    meas->angval = ((double)(int16_t)rawdata[0]) / 65536.0 * 360.0; // Angular value, maps the uint16_t space to 360 degrees
     meas->angspd = 0.0; // Deprecated: this value is no longer provided.
     return no_error; 
 }

--- a/src/absenc_interface/src/absenc.cpp
+++ b/src/absenc_interface/src/absenc.cpp
@@ -1,6 +1,7 @@
 #include "absenc.h"
 #include <iostream>
 
+// We basically re-invented strerr()
 const char* strAbsencErr(int err) {
     switch(err) {
         case NO_ERROR:
@@ -21,6 +22,7 @@ const char* strAbsencErr(int err) {
 ABSENC_Error_t AbsencDriver::OpenPort(const char* fileName, int& s_fd){
     errno = 0; 
 
+    // Open TTY port via native Linux system call. Obtain its file descriptor (fd)
     s_fd = open(fileName, O_RDWR); 
     if(s_fd < 0) {
         int errno0 = errno; 
@@ -31,6 +33,7 @@ ABSENC_Error_t AbsencDriver::OpenPort(const char* fileName, int& s_fd){
             __LINE__, 
         }; 
     }
+    // We do need to configure the TTY port
     struct termios ttycfg; 
     ttycfg.c_cflag = CS8 | CREAD | CLOCAL; // 8N1, ignore modem signals
     ttycfg.c_lflag = 0; 
@@ -52,9 +55,15 @@ ABSENC_Error_t AbsencDriver::OpenPort(const char* fileName, int& s_fd){
             __LINE__, 
         }; 
     }
+
+    // All done, the resource is opened
     return no_error; 
 }
+
+// Poll slave with given slave number and serial port (fd).
+// Return any errors (by value), and measurement results (by pointer).
 ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_fd){
+    // Sanity check for slave numbers
      if(slvnum < 0 || slvnum > 9) {
         return ABSENC_Error_t {
             ERR_SLAVE_INVALID, 
@@ -62,12 +71,14 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
             __LINE__, 
         }; 
     }
-    tcflush(s_fd, TCIOFLUSH); 
+    tcflush(s_fd, TCIOFLUSH); // Flush to ensure no pending TX/RX bytes at port
 
-    char txbuf[2]; 
+    // Now we construct the query packet "#0\n" where 0 represents Node ID
+    char txbuf[3]; 
     txbuf[0] = '#'; 
     txbuf[1] = '0' + slvnum; 
-    int nsend = write(s_fd, txbuf, sizeof(txbuf)); 
+    txbuf[2] = '\n';
+    int nsend = write(s_fd, txbuf, sizeof(txbuf)); // Push to serial port
     if(nsend < 0) {
         int errno0 = errno; 
         errno = 0; 
@@ -79,11 +90,12 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
     }
     // tcdrain(s_fd); // Flush TX buffer? seems not needed
 
-    char sof; 
+    // Now we try to receive the response packet.
+    // First we need to search the start-of-frame symbol, which is fixed '>'. 
+    char sof = 0; 
     for(int i = 0; i < 50; i++) { // Ensure SOF search always ends
         int nrecv = read(s_fd, &sof, 1); 
         if(nrecv < 0) {
-            
             int errno0 = errno; 
             errno = 0; 
             return ABSENC_Error_t{
@@ -92,17 +104,18 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
                 __LINE__, 
             }; 
         }
-        if(nrecv == 0) {
+        if(nrecv == 0) { // Timed out (encoder died)
             return ABSENC_Error_t{
                 ERR_NO_RESPONSE, 
                 0, 
                 __LINE__, 
             }; 
         }
-        if(sof == '#') break; 
+        if(sof == '>') break; // If it is indeed SOF, break out of the loop
         // Not SOF, maybe noise on the bus, search for another one
     }
-    if(sof != '#') {
+    if(sof != '>') {
+        // Not SOF and search limit exceeded. The frame is corrupted or goes very out-of-sync.
         return ABSENC_Error_t{
             ERR_FRAME_CORRUPTED, 
             0, 
@@ -110,7 +123,9 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
         }; 
     }
 
-    char rxbuf[21]; // "X -> AAAA, BBBB, CCCC", ignore the \r\n
+    // Response packets have a fixed format: "> X, AAAA, BBBB". X is slave number, A is position and B is status (usually zero).
+    // Note that we have already received the SOF character. Ignore the \r\n that follows.
+    char rxbuf[21]; 
     int nrecv = read(s_fd, rxbuf, sizeof(rxbuf)); 
     if(nrecv < 0) {
         int errno0 = errno; 
@@ -120,15 +135,7 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
             errno0, 
             __LINE__, 
         }; 
-    }
-
-    // Debug code
-    // if (nrecv > 0) {
-    //     printf("Received %s\n", rxbuf);
-    // } else {
-    //     printf("Received nothing\n");
-    // }
-    
+    }    
     if(nrecv < (int)sizeof(rxbuf)){
         return ABSENC_Error_t{
             ERR_FRAME_CORRUPTED, 
@@ -145,15 +152,14 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
     puts(""); 
     */
 
-   /*
-    TODO : Explain how this works for the people with a skill issue
-   */
-    uint16_t rawdata[3]; 
-    int index = 5; 
-    for(int i = 0; i < 3; i++) {
+    // Recap contents in rxbuf array: " X, AAAA, BBBB"
+    // We ignore X, and start parsing A and B. A has an offset of 4 characters. B mmediatly follows A after 2 characters.
+    uint16_t rawdata[2]; 
+    int index = 4; // Start at rxbuf[4], the start of AAAA
+    for(int i = 0; i < 2; i++) { // Read each hex number (total 2)
         uint16_t val = 0; 
-        for(int j = 0; j < 4; j++) {
-            uint8_t nib = rxbuf[index++]; 
+        for(int j = 0; j < 4; j++) { // Read uint16_t hex number (4 digits)
+            uint8_t nib = rxbuf[index++]; // Read one hex digit (a nibble)
             if(nib >= '0' && nib <= '9') nib = nib - '0'; 
             else if(nib >= 'A' && nib <= 'F') nib = nib - 'A' + 10; 
             else if(nib >= 'a' && nib <= 'f') nib = nib - 'a' + 10; 
@@ -162,17 +168,19 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
                 0, 
                 __LINE__, 
             }; 
+            // Attach the nibble to the value, big-endian format
             val = (val << 4) | nib; 
         }
+        // Once read, we advance pointer by 2 to account for the ", " separator
         index += 2; 
-        rawdata[i] = val; 
+        rawdata[i] = val; // Put value into array
     }
 
-    meas->slvnum = slvnum; 
-    meas->status = rawdata[0]; 
-    meas->angval = ((double)(int16_t)rawdata[1]) / 65536.0 * 360.0; // TODO: fix calibration code on MCU side
-    meas->angspd = (double)(int16_t)rawdata[2]; // TODO: this conversion formula
-    
+    // Construct the measurement data storage object
+    meas->slvnum = slvnum; // Slave number
+    meas->status = rawdata[1]; // Status value (usually zero)
+    meas->angval = ((double)(int16_t)rawdata[1]) / 65536.0 * 360.0; // Angular value, maps the uint16_t space to 360 degrees
+    meas->angspd = 0.0; // Deprecated: this value is no longer provided.
     return no_error; 
 }
 

--- a/src/absenc_interface/src/absenc.cpp
+++ b/src/absenc_interface/src/absenc.cpp
@@ -125,7 +125,7 @@ ABSENC_Error_t AbsencDriver::PollSlave(int slvnum, ABSENC_Meas_t * meas, int s_f
 
     // Response packets have a fixed format: "> X, AAAA, BBBB". X is slave number, A is position and B is status (usually zero).
     // Note that we have already received the SOF character. Ignore the \r\n that follows.
-    char rxbuf[21]; 
+    char rxbuf[14]; 
     int nrecv = read(s_fd, rxbuf, sizeof(rxbuf)); 
     if(nrecv < 0) {
         int errno0 = errno; 


### PR DESCRIPTION
## Encoder Packetization Schema
The encoder schema has changed slightly in 2025 SAR encoder upgrades. This PR updates the current LL driver to match the schema.
- Request packets: `#[d]\n`, where `[d]` is an decimal digit representing the slave number
- Response packets: `> [d], [aaaa], [ssss]\r\n` where `[d]` is the slave number, `[aaaa]` and `[ssss]` are uint16_t hex numbers:
  - `[aaaa]` represents the angular value read by the sensor, mapping uint16_t space to a full revolution. Conversion formula (to degrees): `angularHexValue * 65536.0 / 360.0`
  - `[ssss]` represents the status of the sensor. It is usually zero. It's interpreted as a 16-bit bitfield elaborated below.

## Interpreting Status Bitfields
The status value is usually zero. A non-zero value indicates an error occurred on the sensor side. 
The value is interpreted as follows:
- If the value is `0x0000`, there is no error.
- If the value is `0x8000`, there has been a communication error between the encoder MCU and the encoder sensor chip.
- If the value is non-zero but less than 0x2000, the encoder sensor chip has raised an error. The error code is computed as `REG_STAT & 0x1EFE`, where `REG_STAT` is the status register (0x00) of the TLE5012B encoder sensor. 
- The exact meaning of each bit in the `REG_STAT` register can be found in the _TLE5012B User's Manual_ available online.